### PR TITLE
v3.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-    build: or-tools
-aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+    build: or-tools
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,18 +12,20 @@ source:
 
 build:
   number: 0
-  noarch: python
   entry_points:
     - protoc-gen-mypy = mypy_protobuf.main:main
     - protoc-gen-mypy_grpc = mypy_protobuf.main:grpc
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - protobuf >=3.19.3
     - types-protobuf >=3.19.5
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - protoc-gen-mypy = mypy_protobuf.main:main
     - protoc-gen-mypy_grpc = mypy_protobuf.main:grpc
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<36]
+  skip: true  # [py<37]
 
 requirements:
   host:
@@ -26,8 +26,8 @@ requirements:
     - wheel
   run:
     - python
-    - protobuf >=3.19.3
-    - types-protobuf >=3.19.5
+    - protobuf >=3.19.4
+    - types-protobuf >=3.19.12
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ test:
     - protoc-gen-mypy --version
     - protoc-gen-mypy_grpc --version
     - pip check
-    - python -m pytest
 
 about:
   home: https://github.com/dropbox/mypy-protobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,21 +30,27 @@ requirements:
     - types-protobuf >=3.19.5
 
 test:
+  requires:
+    - pip
   imports:
     - mypy_protobuf
     - mypy_protobuf.extensions_pb2
   commands:
-    - cat /dev/null | protoc-gen-mypy
-    - cat /dev/null | protoc-gen-mypy_grpc
+    - protoc-gen-mypy --version
+    - protoc-gen-mypy_grpc --version
     - pip check
-  requires:
-    - pip
+    - python -m pytest
 
 about:
   home: https://github.com/dropbox/mypy-protobuf
+  dev_url: https://github.com/nipunn1313/mypy-protobuf
+  doc_url: https://github.com/nipunn1313/mypy-protobuf
   summary: Generate mypy stub files from protobuf specs
+  description: |
+    Generate mypy stub files from protobuf specs
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`or-tools` ❄️  -> `mypy-protobuf`

# mypy-protobuf v3.3.0

upstream: https://github.com/nipunn1313/mypy-protobuf/tree/v3.3.0

## Notes
- `abs.yaml` will be removed once https://github.com/AnacondaRecipes/types-protobuf-feedstock/pull/2 is shipped
- This is a new feedstock
- An older version is being built to support or-tools v9.4